### PR TITLE
fix(align_to_char): add missing `length` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ vim.keymap.set(
         local a = require'align'
         a.operator(
             a.align_to_char,
-            { reverse = true }
+            { length = 1, reverse = true }
         )
     end,
     NS


### PR DESCRIPTION
fixes https://github.com/Vonr/align.nvim/issues/12