### PR TITLE
fix: splits closing when using align with preview

### DIFF
--- a/lua/align/init.lua
+++ b/lua/align/init.lua
@@ -99,8 +99,8 @@ local function tmpbuf(marks)
     highlight(sr, sc, er, ec)
 
     return function()
-        vim.api.nvim_buf_delete(tmp, { force = true, unload = false })
         vim.api.nvim_set_current_buf(real)
+        vim.api.nvim_buf_delete(tmp, { force = true, unload = false })
 
         if marks then
             vim.api.nvim_buf_set_mark(real, '[', sr, sc, {})


### PR DESCRIPTION
Fix #19 

When the preview buffer was deleted, it also close the window.
So changing the current buffer of the window first prevent this.